### PR TITLE
Fix incorrect method call in FlaxCropBlock.isLightAdequate()

### DIFF
--- a/src/main/java/paragon/minecraft/wilytextiles/blocks/FlaxCropBlock.java
+++ b/src/main/java/paragon/minecraft/wilytextiles/blocks/FlaxCropBlock.java
@@ -77,7 +77,7 @@ public class FlaxCropBlock extends TallCropBlock {
 	 * @return Whether the light value at the provided {@link BlockPos} is adequate for flax growth.
 	 */
 	protected boolean isLightAdequate(ServerLevel world, BlockPos position) {
-		return world.getLightEmission(position) >= Textiles.CONFIG.flaxMinLight();
+		return world.getRawBrightness(position, 0) >= Textiles.CONFIG.flaxMinLight();
 	}
 
 }


### PR DESCRIPTION
- Call method to check light brightness rather than the one to check block emissiveness
- Fixes Flax crop not growing if min brightness config is nonzero