### PR TITLE
Flax Crop and Basket Fixes/Improvements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,8 +74,12 @@ minecraft {
 sourceSets.main.resources {
 	srcDir 'src/generated/resources'
 	exclude '.cache'
+	exclude '*.DS_Store*'
 }
-sourceSets.main.java { exclude "paragon/minecraft/${packagename}/generators".toString() }
+sourceSets.main.java { 
+	exclude "paragon/minecraft/${packagename}/generators".toString()
+	exclude '*.DS_Store*'
+}
 
 dependencies {
     minecraft "net.minecraftforge:forge:${forge_version}".toString()

--- a/project.config
+++ b/project.config
@@ -10,7 +10,7 @@ ext {
 	mod_id = 'paragon_textiles'
 	packagename = 'wilytextiles'
 	mod_vendor = 'The_Paragon\'s Minecraft Mods'
-	version = '0.3.1'
+	version = '0.3.2'
 	mc_version = '1.18.2'
 	group = 'paragon.minecraft'
 	name = 'WilyTextiles'

--- a/src/main/java/paragon/minecraft/wilytextiles/blocks/BasketBlock.java
+++ b/src/main/java/paragon/minecraft/wilytextiles/blocks/BasketBlock.java
@@ -68,11 +68,11 @@ public abstract class BasketBlock extends BaseEntityBlock implements SimpleWater
 	public static final VoxelShape SHAPE_NORTH_SOUTH = Block.box(OFFSET, 0, 0, 16 - OFFSET, 16 - (OFFSET * 2), 16);
 	public static final VoxelShape SHAPE_EAST_WEST = Block.box(0, 0, OFFSET, 16, 16 - (OFFSET * 2), 16 - OFFSET);
 
-	public static final VoxelShape CAPTURE_UP = Block.box(0, 0, 0, 16, 24, 16);
-	public static final VoxelShape CAPTURE_NORTH = Block.box(0, 0, -8, 0, 16, 16);
-	public static final VoxelShape CAPTURE_SOUTH = Block.box(0, 0, 16, 16, 16, 24);
-	public static final VoxelShape CAPTURE_EAST = Block.box(16, 0, 0, 24, 16, 16);
-	public static final VoxelShape CAPTURE_WEST = Block.box(-8, 0, 0, 0, 16, 16);
+	public static final VoxelShape CAPTURE_UP = SHAPE_UPRIGHT.move(0, 0.5, 0);
+	public static final VoxelShape CAPTURE_NORTH = SHAPE_NORTH_SOUTH.move(0, 0, -0.5);
+	public static final VoxelShape CAPTURE_SOUTH = SHAPE_NORTH_SOUTH.move(0, 0, 0.5);
+	public static final VoxelShape CAPTURE_EAST = SHAPE_EAST_WEST.move(0.5, 0, 0);
+	public static final VoxelShape CAPTURE_WEST = SHAPE_EAST_WEST.move(-0.5, 0, 0);
 
 	public BasketBlock(Properties builder) {
 		super(builder);

--- a/src/main/java/paragon/minecraft/wilytextiles/blocks/BasketBlock.java
+++ b/src/main/java/paragon/minecraft/wilytextiles/blocks/BasketBlock.java
@@ -178,8 +178,8 @@ public abstract class BasketBlock extends BaseEntityBlock implements SimpleWater
 
 	@Override
 	public BlockState getStateForPlacement(BlockPlaceContext context) {
-		Direction facing = context.getClickedFace() == Direction.DOWN ? Direction.UP : context.getClickedFace();
-		return super.getStateForPlacement(context).setValue(BasketBlock.FACING, facing);
+		Direction facing = context.getPlayer().isCrouching() ? context.getNearestLookingDirection().getOpposite() : context.getClickedFace();
+		return super.getStateForPlacement(context).setValue(BasketBlock.FACING, BasketBlock.correctFacing(facing));
 	}
 
 	@Override
@@ -202,6 +202,20 @@ public abstract class BasketBlock extends BaseEntityBlock implements SimpleWater
 	}
 
 	/* Internal Methods */
+	
+	/**
+	 * Baskets cannot face downwards - this method corrects the incoming {@link Direction} property to be compatible
+	 * with the state definition.
+	 * <p>
+	 * If the input {@link Direction} is {@link Direction#DOWN}, returns {@link Direction#UP}. In all other cases, returns
+	 * the input {@link Direction}.
+	 * 
+	 * @param input - The {@link Direction} to correct
+	 * @return A basket blockstate-compatible {@link Direction}.
+	 */
+	protected static Direction correctFacing(Direction input) {
+		return (input == Direction.DOWN) ? Direction.UP: input;
+	}
 
 	/**
 	 * Extracts the {@link #FACING} property from the provided {@link BlockState}.

--- a/src/main/java/paragon/minecraft/wilytextiles/blocks/FlaxCropBlock.java
+++ b/src/main/java/paragon/minecraft/wilytextiles/blocks/FlaxCropBlock.java
@@ -5,12 +5,17 @@ import java.util.Random;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.item.BlockItem;
+import net.minecraft.world.item.ShearsItem;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.SoundType;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.Material;
+import net.minecraftforge.event.entity.player.PlayerEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
+import net.minecraftforge.fml.common.Mod.EventBusSubscriber.Bus;
 import paragon.minecraft.wilytextiles.Textiles;
 import paragon.minecraft.wilytextiles.init.ModBlocks;
 
@@ -19,6 +24,7 @@ import paragon.minecraft.wilytextiles.init.ModBlocks;
  * 
  * @author Malcolm Riley
  */
+@EventBusSubscriber(bus = Bus.FORGE, modid = Textiles.MOD_ID)
 public class FlaxCropBlock extends TallCropBlock {
 	
 	public FlaxCropBlock() {
@@ -27,6 +33,15 @@ public class FlaxCropBlock extends TallCropBlock {
 
 	public FlaxCropBlock(Properties builder) {
 		super(builder);
+	}
+	
+	/* Event Handler Methods */
+	
+	@SubscribeEvent
+	public static void onGetBreakSpeed(PlayerEvent.BreakSpeed event) {
+		if (event.getState().is(Textiles.BLOCKS.FLAX_CROP.get()) && event.getPlayer().getMainHandItem().getItem() instanceof ShearsItem) {
+			event.setNewSpeed(event.getNewSpeed() * Textiles.CONFIG.flaxShearsHarvestModifier());
+		}
 	}
 	
 	/* Public Methods */

--- a/src/main/java/paragon/minecraft/wilytextiles/init/ModConfiguration.java
+++ b/src/main/java/paragon/minecraft/wilytextiles/init/ModConfiguration.java
@@ -17,6 +17,7 @@ public class ModConfiguration extends AbstractConfiguration {
 	/* Internal Fields */
 	protected double BALE_PROGRESS_CHANCE = 0.65D;
 	protected double FLAX_GROWTH_MODIFIER = 1.0D;
+	protected float FLAX_SHEARS_HARVEST_MODIFIER = 1.0F;
 	protected int FLAX_MIN_LIGHTLEVEL = 8;
 	protected boolean SHEPHERD_TRADES_FABRIC = true;
 	protected boolean WANDERER_TRADES_FABRIC = true;
@@ -48,6 +49,13 @@ public class ModConfiguration extends AbstractConfiguration {
 	 */
 	public double flaxGrowthModifier() {
 		return this.FLAX_GROWTH_MODIFIER;
+	}
+	
+	/**
+	 * @return The bonus break speed awarded when breaking Flax crops with shears.
+	 */
+	public float flaxShearsHarvestModifier() {
+		return 1.0F + this.FLAX_SHEARS_HARVEST_MODIFIER;
 	}
 	
 	/**
@@ -140,6 +148,11 @@ public class ModConfiguration extends AbstractConfiguration {
 				"The minimum light level that Flax needs in order to grow.",
 				"The light level at the crop's position must equal or exceed this value, else no growth will occur.")
 			.defineInRange("flax_min_lightlevel", 8, 0, 15));
+		this.defineValue(value -> this.FLAX_SHEARS_HARVEST_MODIFIER = value.floatValue(), builder
+			.comment("The additive percentage harvest speed bonus awarded when breaking flax crops with shears.",
+				"For example, a value of 1.0 means a break speed bonus of +100% (twice as fast), and a value of 2.53 means a break speed bonus of +253% (more than three times as fast).",
+				"Modify with caution as this value is cumulative with other effects that modify break speed, such as potion effects.")
+			.defineInRange("flax_shears_harvest_bonus", 1.0, 0.0, Double.MAX_VALUE));
 		builder.pop();
 		
 		builder.push("Trading");


### PR DESCRIPTION
- Fix server crash related to `VoxelShape` computation for basket block capture bounds
- Placing a basket while crouching will orient the open face towards the player. When not crouching, will orient the face to the same direction as the face of the clicked block (same as before).
- Configurable break speed bonus when breaking Flax with Shears